### PR TITLE
スマホFooterの色付けとアプリ名変更

### DIFF
--- a/hacku-team1/src/components/molecules/AppName.tsx
+++ b/hacku-team1/src/components/molecules/AppName.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import Typography from '@material-ui/core/Typography';
+import React from "react";
+import Typography from "@material-ui/core/Typography";
 
 type Props = {
   className: string;
-}
+};
 
 const AppName: React.FC<Props> = ({ className }) => {
   return (
     <Typography className={className} variant="h4" noWrap>
-      AppName
+      しろ-せん
     </Typography>
-  )
-}
+  );
+};
 
 export default AppName;

--- a/hacku-team1/src/components/molecules/SectionBar.tsx
+++ b/hacku-team1/src/components/molecules/SectionBar.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       bottom: 0,
       zIndex: 1000,
       textAlign: "center",
-      backgroundColor: "gray",
+      backgroundColor: "#bb4d54",
       margin: 0,
     },
   },


### PR DESCRIPTION
# スマホFooterの色付けとアプリ名変更
- スマホ画面での下部のFooterに色を適用（ベタがきなので注意）
- アプリ名を適用